### PR TITLE
Use os.getenv's default values

### DIFF
--- a/krampus.py
+++ b/krampus.py
@@ -52,26 +52,11 @@ class Krampus():
 
 def main(event, context):
     # collect our run information, otherwise just give it something I guess
-    if os.getenv("DEFAULT_REGION"):
-        region = os.getenv("DEFAULT_REGION")
-    else:
-        region = "us-east-1"
-    if os.getenv("KRAMPUS_BUCKET"):
-        krampus_bucket = os.getenv("KRAMPUS_BUCKET")
-    else:
-        krampus_bucket = "krampus-dev"
-    if os.getenv("TASKS_FILE_KEY"):
-        tasks_file_key = os.getenv("TASKS_FILE_KEY")
-    else:
-        tasks_file_key = "tasks.json"
-    if os.getenv("ARN_WHITELIST"):
-        whitelist = os.getenv("ARN_WHITELIST")
-    else:
-        whitelist = None
-    if os.getenv("KRAMPUS_ROLE_NAME"):
-        krampus_role = os.getenv("KRAMPUS_ROLE_NAME")
-    else:
-        krampus_role = "krampus"
+    region = os.getenv("DEFAULT_REGION", "us-east-1")
+    krampus_bucket = os.getenv("KRAMPUS_BUCKET", "krampus-dev")
+    tasks_file_key = os.getenv("TASKS_FILE_KEY", "tasks.json")
+    whitelist = os.getenv("ARN_WHITELIST")
+    krampus_role = os.getenv("KRAMPUS_ROLE_NAME", "krampus")
     # fire it all up
     k = Krampus(region, krampus_bucket, tasks_file_key, whitelist, krampus_role)
     k.getTasks()


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.

### Short description of what this PR does:
- Use [`os.getenv`](https://docs.python.org/2/library/os.html#os.getenv)'s default values (this also conforms to Python's preference of [EAFP](https://docs.python.org/3/glossary.html#term-eafp) over [LBYL](https://docs.python.org/3/glossary.html#term-lbyl))

https://github.com/sendgrid/krampus/blob/738f00652abc93302db5b1205ab3ba45f2507463/krampus.py#L55-L58

```python
>>> os.getenv("DEFAULT_REGION", "us-east-1")
'us-east-1'
```

https://github.com/sendgrid/krampus/blob/738f00652abc93302db5b1205ab3ba45f2507463/krampus.py#L67-L70
```python
>>> os.getenv("ARN_WHITELIST") is None
True
```
