### PR TITLE
Use sys.exit instead of exit, reorder imports

### DIFF
--- a/kinder/ebs.py
+++ b/kinder/ebs.py
@@ -8,6 +8,7 @@
 ###############################################################################
 # TODO:
 ###############################################################################
+import sys
 from re import search
 
 from kinder.ec2 import EC2  # need to work with instance parents
@@ -20,7 +21,7 @@ class EBS():
             self.conn = sess.resource("ec2", region_name=region)
         except Exception as e:
             KLog.log("issue connecting to AWS %s" % str(e), "critical")
-            exit("[!] issue connecting to AWS: %s" % str(e))
+            sys.exit("[!] issue connecting to AWS: %s" % str(e))
         # get volume reference
         self.volume = self.conn.Volume(volume_id)
         self.region = region

--- a/kinder/ec2.py
+++ b/kinder/ec2.py
@@ -5,6 +5,8 @@
 ###############################################################################
 # TODO:
 ###############################################################################
+import sys
+
 from botocore.exceptions import ClientError
 
 from lib.krampus_logging import KLog
@@ -16,7 +18,7 @@ class EC2():
             self.conn = sess.resource("ec2", region)
         except Exception as e:
             KLog.log("issue connecting to AWS %s" % str(e), "critical")
-            exit("[!] issue connecting to AWS: %s" % str(e))
+            sys.exit("[!] issue connecting to AWS: %s" % str(e))
         # set it
         self.instance = self.getInstanceByID(instance_id)
         # verify the instance

--- a/kinder/lambda_funcs.py
+++ b/kinder/lambda_funcs.py
@@ -5,6 +5,8 @@
 ###############################################################################
 # TODO:
 ###############################################################################
+import sys
+
 from lib.krampus_logging import KLog
 
 
@@ -14,7 +16,7 @@ class Lambda():
             self.conn = sess.client("lambda", region_name=region)
         except Exception as e:
             KLog.log("issue connecting to AWS %s" % str(e), "critical")
-            exit("[!] issue connecting to AWS: %s" % str(e))
+            sys.exit("[!] issue connecting to AWS: %s" % str(e))
         # get volume reference
         self.func = func_name
         self.region = region

--- a/kinder/rds.py
+++ b/kinder/rds.py
@@ -6,6 +6,8 @@
 # TODO:
 # add more disable groups/rules
 ###############################################################################
+import sys
+
 from lib.krampus_logging import KLog
 
 
@@ -15,7 +17,7 @@ class RDS():
             self.conn = sess.client('rds', region_name=region)
         except:
             KLog.log("issue connecting to AWS", "critical")
-            exit("[!] issue connecting to AWS")
+            sys.exit("[!] issue connecting to AWS")
         # set it
         self.name = instance_name
         self.disable_groups = ['sg-c6d41cae']

--- a/kinder/s3.py
+++ b/kinder/s3.py
@@ -7,6 +7,8 @@
 ###############################################################################
 # TODO:
 ###############################################################################
+import sys
+
 from lib.krampus_logging import KLog
 
 
@@ -16,7 +18,7 @@ class S3():
             self.conn = sess.resource("s3", region_name=region)
         except:
             KLog.log("issue connecting to AWS", "critical")
-            exit("[!] issue connecting to AWS")
+            sys.exit("[!] issue connecting to AWS")
         # set it - as far as krampus is concerned the acls are the bucket
         self.bucket = self.conn.BucketAcl(bucket_name)
 

--- a/kinder/security_group.py
+++ b/kinder/security_group.py
@@ -4,7 +4,10 @@
 # TODO:
 # no ipv6 support
 ###############################################################################
+import sys
+
 from botocore.exceptions import ClientError
+
 from lib.krampus_logging import KLog
 
 
@@ -20,7 +23,7 @@ class SecurityGroup():
             self.group = False
         except:
             KLog.log("issue connecting to AWS", "critical")
-            exit("[!] issue connecting to AWS")
+            sys.exit("[!] issue connecting to AWS")
 
     # see if there is a specified range in this rule
     def hasRange(self, rules, cidr_range):

--- a/lib/krampus_tasks.py
+++ b/lib/krampus_tasks.py
@@ -4,22 +4,23 @@
 # TODO:
 # all these tasks should return a status to krampus.py
 ###############################################################################
+import json
+import sys
+import time
+
 import boto3
 from botocore.exceptions import ClientError
-import json
-import time
-import sys
 
+from kinder import ebs
 # our stuff
 from kinder import ec2
 from kinder import iam
+from kinder import lambda_funcs
 from kinder import rds
 from kinder import s3
 from kinder import security_group
-from kinder import ebs
-from kinder import lambda_funcs
-from lib.krampus_logging import KLog
 from lib.aws_sessions import KSession
+from lib.krampus_logging import KLog
 
 # not sure what keys will be passed, but I do know how what krampus wants
 KEYS = {
@@ -240,7 +241,7 @@ class KTask():
             self.json_data = json.load(self.bucket.Object(key).get()['Body'])
         except ClientError as e:
             KLog.log("failed to download tasks file: %s" % str(e), "critical")
-            exit()
+            sys.exit()
         for job in self.json_data['tasks']:
             # resolve the arn
             arn_obj = KTask.ARN(job[KEYS['arn']])


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.

### Short description of what this PR does:
- Use [`sys.exit`](https://docs.python.org/3/library/sys.html#sys.exit) instead of [`exit`](https://docs.python.org/3/library/constants.html#exit)
    > [The site module (which is imported automatically during startup, except if the -S command-line option is given) adds several constants to the built-in namespace. They are useful for the interactive interpreter shell and should not be used in programs.](https://docs.python.org/3/library/constants.html?highlight=exit#constants-added-by-the-site-module)
- Reorder import according to PEP8
    > Imports should be grouped in the following order:
    >
    >    * standard library imports
    >    * related third party imports
    >    * local application/library specific imports

    * https://pep8.org/#imports
